### PR TITLE
Installing httpd on 'web' container grp

### DIFF
--- a/lxc-main.yml
+++ b/lxc-main.yml
@@ -30,3 +30,4 @@
         line: lxc.network.link=br0
 
     - include_tasks: lxc-create.yml
+    - include_tasks: web.yml

--- a/web.yml
+++ b/web.yml
@@ -1,0 +1,12 @@
+---
+    - name: Install webserver on the web group
+      lxc_container:
+        name: "{{ item }}"
+        template: centos
+        container_command: |
+          yum install -y httpd
+          yum install -y mod_ssl
+          /usr/sbin/apachectl start
+          iptables -I INPUT 1 -p tcp --dport 80 -j ACCEPT
+      with_items: "{{ groups['web'] }}"
+


### PR DESCRIPTION
This branch was created in order to install httpd server on the containers listed under 'web' group in hosts file.